### PR TITLE
[Bounty $200] feat: OAuth authentication — Google, GitHub, Apple

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# ── OAuth Providers ──
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+APPLE_CLIENT_ID=
+APPLE_TEAM_ID=
+APPLE_KEY_ID=
+APPLE_KEY_FILE_PATH=
+
+# ── JWT ──
+JWT_SECRET=change-me-to-a-random-string
+
+# ── URLs ──
+API_URL=http://localhost:3000
+FRONTEND_URL=http://localhost:4200
+NEXT_PUBLIC_API_URL=http://localhost:3000/api

--- a/apps/backend/src/app/app.module.ts
+++ b/apps/backend/src/app/app.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
+import { AuthModule } from './auth/auth.module';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 
 @Module({
-  imports: [],
+  imports: [AuthModule, ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/backend/src/app/auth/auth.controller.ts
+++ b/apps/backend/src/app/auth/auth.controller.ts
@@ -1,0 +1,57 @@
+import { Controller, Get, Req, Res, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { Response } from 'express';
+import { AuthService } from './auth.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  // ── Google ──
+  @Get('google')
+  @UseGuards(AuthGuard('google'))
+  async googleAuth() {}
+
+  @Get('google/callback')
+  @UseGuards(AuthGuard('google'))
+  async googleCallback(@Req() req: any, @Res() res: Response) {
+    const { accessToken } = await this.authService.validateOAuthLogin(req.user);
+    this.redirectWithToken(res, accessToken);
+  }
+
+  // ── GitHub ──
+  @Get('github')
+  @UseGuards(AuthGuard('github'))
+  async githubAuth() {}
+
+  @Get('github/callback')
+  @UseGuards(AuthGuard('github'))
+  async githubCallback(@Req() req: any, @Res() res: Response) {
+    const { accessToken } = await this.authService.validateOAuthLogin(req.user);
+    this.redirectWithToken(res, accessToken);
+  }
+
+  // ── Apple ──
+  @Get('apple')
+  @UseGuards(AuthGuard('apple'))
+  async appleAuth() {}
+
+  @Get('apple/callback')
+  @UseGuards(AuthGuard('apple'))
+  async appleCallback(@Req() req: any, @Res() res: Response) {
+    const { accessToken } = await this.authService.validateOAuthLogin(req.user);
+    this.redirectWithToken(res, accessToken);
+  }
+
+  // ── Me ──
+  @Get('me')
+  @UseGuards(AuthGuard('jwt'))
+  getProfile(@Req() req: any) {
+    return req.user;
+  }
+
+  private redirectWithToken(res: Response, token: string) {
+    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:4200';
+    res.redirect(`${frontendUrl}/auth/callback?token=${token}`);
+  }
+}

--- a/apps/backend/src/app/auth/auth.module.ts
+++ b/apps/backend/src/app/auth/auth.module.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { GoogleStrategy } from './strategies/google.strategy';
+import { GithubStrategy } from './strategies/github.strategy';
+import { AppleStrategy } from './strategies/apple.strategy';
+import { JwtStrategy } from './strategies/jwt.strategy';
+
+@Module({
+  imports: [
+    PassportModule.register({ defaultStrategy: 'jwt' }),
+    JwtModule.register({
+      secret: process.env.JWT_SECRET || 'dev-secret-change-me',
+      signOptions: { expiresIn: '7d' },
+    }),
+  ],
+  controllers: [AuthController],
+  providers: [
+    AuthService,
+    GoogleStrategy,
+    GithubStrategy,
+    AppleStrategy,
+    JwtStrategy,
+  ],
+  exports: [AuthService, JwtModule],
+})
+export class AuthModule {}

--- a/apps/backend/src/app/auth/auth.service.ts
+++ b/apps/backend/src/app/auth/auth.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+
+export interface OAuthProfile {
+  provider: string;
+  providerId: string;
+  email: string;
+  name: string;
+  avatar?: string;
+}
+
+@Injectable()
+export class AuthService {
+  constructor(private readonly jwtService: JwtService) {}
+
+  async validateOAuthLogin(profile: OAuthProfile): Promise<{ accessToken: string }> {
+    // In production: upsert user in DB, link provider accounts.
+    // For now: issue JWT with the profile payload.
+    const payload = {
+      sub: `${profile.provider}:${profile.providerId}`,
+      email: profile.email,
+      name: profile.name,
+      avatar: profile.avatar,
+      provider: profile.provider,
+    };
+
+    const accessToken = this.jwtService.sign(payload);
+    return { accessToken };
+  }
+
+  verifyToken(token: string): Record<string, any> | null {
+    try {
+      return this.jwtService.verify(token);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/apps/backend/src/app/auth/strategies/apple.strategy.ts
+++ b/apps/backend/src/app/auth/strategies/apple.strategy.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import AppleStrategy from 'passport-apple';
+
+@Injectable()
+export class AppleSignInStrategy extends PassportStrategy(AppleStrategy, 'apple') {
+  constructor() {
+    super({
+      clientID: process.env.APPLE_CLIENT_ID || '',
+      teamID: process.env.APPLE_TEAM_ID || '',
+      keyID: process.env.APPLE_KEY_ID || '',
+      keyFilePath: process.env.APPLE_KEY_FILE_PATH || '',
+      callbackURL: `${process.env.API_URL || 'http://localhost:3000'}/api/auth/apple/callback`,
+      scope: ['email', 'name'],
+    });
+  }
+
+  async validate(
+    accessToken: string,
+    refreshToken: string,
+    profile: any,
+    done: any,
+  ): Promise<any> {
+    const { id } = profile;
+    const email = profile.email || '';
+    const name = profile.name
+      ? `${profile.name.firstName || ''} ${profile.name.lastName || ''}`.trim()
+      : 'Apple User';
+    const user = {
+      provider: 'apple',
+      providerId: id,
+      email,
+      name,
+    };
+    done(null, user);
+  }
+}

--- a/apps/backend/src/app/auth/strategies/github.strategy.ts
+++ b/apps/backend/src/app/auth/strategies/github.strategy.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy } from 'passport-github2';
+
+@Injectable()
+export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
+  constructor() {
+    super({
+      clientID: process.env.GITHUB_CLIENT_ID || '',
+      clientSecret: process.env.GITHUB_CLIENT_SECRET || '',
+      callbackURL: `${process.env.API_URL || 'http://localhost:3000'}/api/auth/github/callback`,
+      scope: ['user:email'],
+    });
+  }
+
+  async validate(
+    accessToken: string,
+    refreshToken: string,
+    profile: any,
+    done: any,
+  ): Promise<any> {
+    const { id, displayName, username, emails, photos } = profile;
+    const user = {
+      provider: 'github',
+      providerId: id,
+      email: emails?.[0]?.value || `${username}@github.users`,
+      name: displayName || username,
+      avatar: photos?.[0]?.value,
+    };
+    done(null, user);
+  }
+}

--- a/apps/backend/src/app/auth/strategies/google.strategy.ts
+++ b/apps/backend/src/app/auth/strategies/google.strategy.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy, VerifyCallback } from 'passport-google-oauth20';
+
+@Injectable()
+export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
+  constructor() {
+    super({
+      clientID: process.env.GOOGLE_CLIENT_ID || '',
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
+      callbackURL: `${process.env.API_URL || 'http://localhost:3000'}/api/auth/google/callback`,
+      scope: ['email', 'profile'],
+    });
+  }
+
+  async validate(
+    accessToken: string,
+    refreshToken: string,
+    profile: any,
+    done: VerifyCallback,
+  ): Promise<any> {
+    const { id, displayName, emails, photos } = profile;
+    const user = {
+      provider: 'google',
+      providerId: id,
+      email: emails?.[0]?.value || '',
+      name: displayName,
+      avatar: photos?.[0]?.value,
+    };
+    done(null, user);
+  }
+}

--- a/apps/backend/src/app/auth/strategies/jwt.strategy.ts
+++ b/apps/backend/src/app/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: process.env.JWT_SECRET || 'dev-secret-change-me',
+    });
+  }
+
+  async validate(payload: any) {
+    return {
+      sub: payload.sub,
+      email: payload.email,
+      name: payload.name,
+      avatar: payload.avatar,
+      provider: payload.provider,
+    };
+  }
+}

--- a/apps/frontend/src/app/auth/callback/page.tsx
+++ b/apps/frontend/src/app/auth/callback/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+export default function AuthCallbackPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const token = searchParams.get("token");
+    if (token) {
+      localStorage.setItem("auth_token", token);
+      router.push("/");
+    } else {
+      router.push("/auth/login?error=no_token");
+    }
+  }, [searchParams, router]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <p className="text-lg">Signing you in…</p>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/auth/login/page.tsx
+++ b/apps/frontend/src/app/auth/login/page.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000/api";
+
+export default function LoginPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="w-full max-w-md rounded-xl bg-white p-8 shadow-lg">
+        <h1 className="mb-2 text-center text-2xl font-bold text-gray-900">
+          Welcome to NFT Marketplace
+        </h1>
+        <p className="mb-8 text-center text-sm text-gray-500">
+          Sign in to start trading
+        </p>
+
+        <div className="space-y-3">
+          <a
+            href={`${API_URL}/auth/google`}
+            className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 shadow-sm transition hover:bg-gray-50"
+          >
+            <svg className="h-5 w-5" viewBox="0 0 24 24">
+              <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"/>
+              <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+              <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+              <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+            </svg>
+            Continue with Google
+          </a>
+
+          <a
+            href={`${API_URL}/auth/github`}
+            className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-[#24292e] px-4 py-3 text-sm font-medium text-white shadow-sm transition hover:bg-[#1b1f23]"
+          >
+            <svg className="h-5 w-5" fill="white" viewBox="0 0 24 24">
+              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.385-1.335-1.755-1.335-1.755-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 21.795 24 17.295 24 12c0-6.63-5.37-12-12-12z"/>
+            </svg>
+            Continue with GitHub
+          </a>
+
+          <a
+            href={`${API_URL}/auth/apple`}
+            className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-black px-4 py-3 text-sm font-medium text-white shadow-sm transition hover:bg-gray-800"
+          >
+            <svg className="h-5 w-5" fill="white" viewBox="0 0 24 24">
+              <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.08-.42 1.45-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
+            </svg>
+            Continue with Apple
+          </a>
+        </div>
+
+        <p className="mt-6 text-center text-xs text-gray-400">
+          By signing in, you agree to our Terms of Service.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/auth/useAuth.ts
+++ b/apps/frontend/src/app/auth/useAuth.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+interface User {
+  sub: string;
+  email: string;
+  name: string;
+  avatar?: string;
+  provider: string;
+}
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000/api";
+
+export function useAuth() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    const token = localStorage.getItem("auth_token");
+    if (!token) {
+      setLoading(false);
+      return;
+    }
+    fetch(`${API_URL}/auth/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.email) setUser(data);
+        else localStorage.removeItem("auth_token");
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const login = (provider: "google" | "github" | "apple") => {
+    window.location.href = `${API_URL}/auth/${provider}`;
+  };
+
+  const logout = () => {
+    localStorage.removeItem("auth_token");
+    setUser(null);
+    router.push("/");
+  };
+
+  return { user, loading, login, logout, isAuthenticated: !!user };
+}


### PR DESCRIPTION
## OAuth Authentication — Google, GitHub, Apple

Implements native OAuth 2.0 login without third-party services (no Clerk, no NextAuth).

### Backend (NestJS + Passport)

```
apps/backend/src/app/auth/
├── auth.module.ts          # Passport + JWT module
├── auth.controller.ts      # /auth/google, /auth/github, /auth/apple, /auth/me
├── auth.service.ts         # JWT issuance + verification
└── strategies/
    ├── google.strategy.ts  # passport-google-oauth20
    ├── github.strategy.ts  # passport-github2
    ├── apple.strategy.ts   # passport-apple
    └── jwt.strategy.ts     # Bearer token validation
```

### Frontend (Next.js 14)

```
apps/frontend/src/app/auth/
├── login/page.tsx          # OAuth provider buttons (Google, GitHub, Apple)
├── callback/page.tsx       # Token capture → localStorage → redirect
└── useAuth.ts              # Client hook: user state, login(), logout()
```

### Flow
1. User clicks provider button → redirects to NestJS OAuth route
2. Passport handles OAuth dance → calls `AuthService.validateOAuthLogin()`
3. JWT issued → redirects to `/auth/callback?token=xxx`
4. Frontend stores token → calls `GET /auth/me` → full user state
5. `useAuth()` hook provides reactive `{ user, login, logout, isAuthenticated }`

### Environment Variables (`.env.example`)
```
GOOGLE_CLIENT_ID=       # from Google Cloud Console
GOOGLE_CLIENT_SECRET=
GITHUB_CLIENT_ID=       # from GitHub OAuth Apps
GITHUB_CLIENT_SECRET=
APPLE_CLIENT_ID=        # from Apple Developer
APPLE_TEAM_ID=
APPLE_KEY_ID=
JWT_SECRET=             # random string
```

Closes #2